### PR TITLE
FIX(Issue/1): Use table content rather than header when adding rows

### DIFF
--- a/src/SpecFlow.Contrib.Variants.SpecFlowPlugin/Generator/FeatureGeneratorExtended.cs
+++ b/src/SpecFlow.Contrib.Variants.SpecFlowPlugin/Generator/FeatureGeneratorExtended.cs
@@ -159,7 +159,7 @@ namespace SpecFlow.Contrib.Variants.SpecFlowPlugin.Generator
                 else
                     GenerateScenarioOutlineExamplesAsIndividualMethods(scenarioOutline, generationContext, outlineTestMethod, identifierMapping, null);
             }
-            //NEW CODE END    
+            //NEW CODE END
 
             var referenceExpression = new CodeVariableReferenceExpression("exampleTags");
             GenerateTestBody(generationContext, scenarioOutline, outlineTestMethod, referenceExpression, identifierMapping);
@@ -429,7 +429,7 @@ namespace SpecFlow.Contrib.Variants.SpecFlowPlugin.Generator
             {
                 statements.Add(new CodeMethodInvokeExpression(referenceExpression, "AddRow", new CodeExpression[1]
                 {
-                    tableRow1.Cells.Select(c => c.Value).GetStringArrayExpression(paramToIdentifier)
+                    tableRow2.Cells.Select(c => c.Value).GetStringArrayExpression(paramToIdentifier)
                 }));
             }
             return referenceExpression;

--- a/src/SpecFlow.Contrib.Variants/Generator/FeatureGeneratorExtended.cs
+++ b/src/SpecFlow.Contrib.Variants/Generator/FeatureGeneratorExtended.cs
@@ -164,7 +164,7 @@ namespace SpecFlow.Contrib.Variants.Generator
                 else
                     GenerateScenarioOutlineExamplesAsIndividualMethods(scenarioOutline, generationContext, outlineTestMethod, identifierMapping, null);
             }
-            //NEW CODE END    
+            //NEW CODE END
 
             var referenceExpression = new CodeVariableReferenceExpression("exampleTags");
             GenerateTestBody(generationContext, scenarioOutline, outlineTestMethod, referenceExpression, identifierMapping);
@@ -434,7 +434,7 @@ namespace SpecFlow.Contrib.Variants.Generator
             {
                 statements.Add(new CodeMethodInvokeExpression(referenceExpression, "AddRow", new CodeExpression[1]
                 {
-                    tableRow1.Cells.Select(c => c.Value).GetStringArrayExpression(paramToIdentifier)
+                    tableRow2.Cells.Select(c => c.Value).GetStringArrayExpression(paramToIdentifier)
                 }));
             }
             return referenceExpression;


### PR DESCRIPTION
Fixes a bug with table generation whereby instead of adding the content of each row, the table header is repeated for each row.